### PR TITLE
Generate the full output path on split, not just the leaf directory

### DIFF
--- a/src/m4b_util/helpers/splitter.py
+++ b/src/m4b_util/helpers/splitter.py
@@ -1,7 +1,7 @@
 """The Splitter Class."""
 from m4b_util.helpers import cover_utils
 from m4b_util.helpers.parallel_ffmpeg import ParallelFFmpeg
-
+import os
 
 def split(
         input_path,
@@ -27,7 +27,10 @@ def split(
     for i, segment in enumerate(segment_list):
         time = segment.end_time - segment.start_time
 
-        output_dir_path.mkdir(exist_ok=True)
+        # Create the full path down to the place where the output file will go, rather
+        # than just the leaf directory.
+        if not os.path.exists(output_dir_path):
+            os.makedirs(output_dir_path, exist_ok=True)
         output_path = output_dir_path / output_pattern.format(i, i=i, title=segment.title)
 
         # Set up our FFMPEG command


### PR DESCRIPTION
When I used the `split` command, the value in the `-o` parameter would only create the immediate directory where the split mp3 files would go.

My library is set up as author/title with optional series in there as author/series/title. I was splitting a bunch of m4b files into mp3 and the code would fail because my batch file just had the top-level directory existing, but none of the intermediate directories, such as author name and series. 

`output_dir_path.mkdir()` won't create the full path, but `os.makedirs(output_dir_path)` will.

I looked for other locations where the project is using Path.mkdir() and they all seem to be test cases.